### PR TITLE
Fixes for latest rust and fix docopt flags

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,7 +126,7 @@ fn main() {
 
         let name = deuterium_orm::migration::create_migration_file(
           &args.arg_migration_name[..],
-          path::PathBuf::new("src/db/migrations")
+          path::PathBuf::from("src/db/migrations")
         );
 
         println!("Migration with name {} was generated.", name);

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ extern crate postgres;
 extern crate rustless;
 extern crate typemap;
 extern crate time;
-extern crate "rustc-serialize" as rustc_serialize;
+extern crate rustc_serialize;
 extern crate iron;
 extern crate docopt;
 extern crate uuid;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,5 @@
 #![feature(plugin)]
-#![feature(core)]
-#![feature(path)]
-#![feature(net)]
+#![feature(ip_addr)]
 
 #![plugin(deuterium_plugin)]
 #![plugin(docopt_macros)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,11 +38,12 @@ docopt!(Args derive Debug, "
 Example backend.
 
 Usage:
-  backend run
+  backend [--ip=<ip>] [--port=<port>] run
   backend g migration <migration-name>
   backend db migrate [<version>]
   backend db rollback [<steps>]
   backend --version
+  backend --help
 
 Options:
   -h --help        Show this screen.

--- a/src/models/tweet.rs
+++ b/src/models/tweet.rs
@@ -14,8 +14,8 @@ pub struct Tweet {
 impl Tweet {
 
     pub fn get_id(&self) -> &uuid::Uuid { &self.id }
-    pub fn get_author_name(&self) -> &str { self.author_name.as_slice() }
-    pub fn get_content(&self) -> &str { self.content.as_slice() }
+    pub fn get_author_name(&self) -> &str { &self.author_name }
+    pub fn get_content(&self) -> &str { &self.content }
     pub fn get_created_at(&self) -> &time::Timespec { &self.created_at }
     pub fn get_updated_at(&self) -> &time::Timespec { &self.updated_at }
 


### PR DESCRIPTION
With docopt the valid flags for each command need to be specified, otherwise they can't be used.
